### PR TITLE
chore: enable with fetch

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -3,12 +3,12 @@ import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 import { provideClientHydration } from '@angular/platform-browser';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withFetch } from '@angular/common/http';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes),
     provideClientHydration(),
-    provideHttpClient(),
+    provideHttpClient(withFetch()),
   ],
 };


### PR DESCRIPTION
# Descrição

Ao rodar o projeto localmente, podemos deparar com um alerta de configuração do provideHttpClient. Acredito que seja por conta do SSR habilitado no projeto.

_NG02801: Angular detected that `HttpClient` is not configured to use `fetch` APIs. It's strongly recommended to enable `fetch` for applications that use Server-Side Rendering for better performance and compatibility. To enable `fetch`, add the `withFetch()` to the `provideHttpClient()` call at the root of the application._

![image](https://github.com/Fernanda-Kipper/eventostec-frontend/assets/114026716/8c219199-6239-4900-88fc-735b8ed0e79e)

## O que foi alterado?

- [ ] Nova funcionalidade
- [ ] Correção de bug
- [ ] Melhorias na documentação
- [x] Outro (especificar): alerta de configuração do provideHttpClient

## Issue relacionada

Este Pull Request resolve uma issue?

- [ ] Sim
- [x] Não

Se sim, por favor, insira o link da issue:

[Link para a issue](INSIRA O LINK AQUI)

# Checklist

- [x] Eu revisei meu código
- [x] Eu fiz um teste local das minhas alterações
- [ ] Atualizei o README.md com meu nome nos contribuidores

# Comentários adicionais

Depois da correção, saiu o alerta.
![image](https://github.com/Fernanda-Kipper/eventostec-frontend/assets/114026716/313c46c6-6492-4654-9b9a-5a72ae83e580)

